### PR TITLE
[15.0][FIX] sale_comment_template: fix action to allow to see templates in sales

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Do NOT update manually; changes here will be overwritten by Copier
-_commit: v1.20
+_commit: v1.21.1
 _src_path: gh:oca/oca-addons-repo-template
 ci: GitHub
 convert_readme_fragments_to_markdown: false

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Stale PRs and issues policy
-        uses: actions/stale@v4
+        uses: actions/stale@v9
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           # General settings.
@@ -48,7 +48,7 @@ jobs:
       # * Issues that are pending more information
       # * Except Issues marked as "no stale"
       - name: Needs more information stale issues policy
-        uses: actions/stale@v4
+        uses: actions/stale@v9
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           ascending: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,9 @@ jobs:
         run: oca_init_test_database
       - name: Run tests
         run: oca_run_tests
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
       - name: Update .pot files
         run: oca_export_and_push_pot https://x-access-token:${{ secrets.GIT_PUSH_TOKEN }}@github.com/${{ github.repository }}
         if: ${{ matrix.makepot == 'true' && github.event_name == 'push' && github.repository_owner == 'OCA' }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,8 @@ exclude: |
   readme/.*\.(rst|md)$|
   # Ignore build and dist directories in addons
   /build/|/dist/|
+  # Ignore test files in addons
+  /tests/samples/.*|
   # You don't usually want a bot to modify your legal texts
   (LICENSE.*|COPYING.*)
 default_language_version:

--- a/sale_comment_template/views/base_comment_template_view.xml
+++ b/sale_comment_template/views/base_comment_template_view.xml
@@ -5,11 +5,8 @@
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">base.comment.template</field>
         <field name="view_mode">tree,form</field>
-        <field name="domain">[('model_ids.model', '=', 'sale.order')]</field>
-        <field
-            name="context"
-            eval="{'default_model_ids': [(4, ref('sale.model_sale_order'))]}"
-        />
+        <field name="domain">[('model_ids', '=', 'sale.order')]</field>
+        <field name="context">{'default_models': 'sale.order'}</field>
         <field
             name="view_id"
             ref="base_comment_template.view_base_comment_template_tree"


### PR DESCRIPTION
I reopen the PR https://github.com/OCA/sale-reporting/pull/260

This commit addresses the following issues:
Resolved an issue where users were unable to view templates in the comment list due to an incorrect domain configuration in the action.
Updated the context to set the sale order as the default option.